### PR TITLE
Use the gain crossover 'wc' as a first guess for solving the phase crossover frequency

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -632,7 +632,7 @@ def margins(G):
         return numpy.angle(Gw(w)) + numpy.pi
 
     # where the freqeuncy is calculated where arg G(jw) = -180 deg
-    w_180 = optimize.fsolve(arg, -1)
+    w_180 = optimize.fsolve(arg, wc)
 
     PM = numpy.angle(Gw(wc), deg=True) + 180
     GM = 1/(numpy.abs(Gw(w_180)))
@@ -752,7 +752,7 @@ def bode(G, w1, w2, label='Figure', margin=False):
     
     plt.show()
 
-    return GM, PM
+    return GM, PM, wc, w_180
     
 def bodeclosedloop(G, K, w1, w2, label='Figure', margin=False):
     """ 


### PR DESCRIPTION
There were a plotting error with the bode() function and ZiergerNicols function in utils.py because the phase crossover frequency 'w_180' returned by margins() was negative (and can't plot a negative number on a log axis).
There are multiple solutions for w_180 for each revolution (360n) and depending on the initial guess this could cause the solution to be out by a phase 360n. There is only one solution for wc and w_180 should be close to wc, therefore wc should be a good first estimate for w_180
