### PR TITLE
Pzcancel

### DIFF
--- a/Figure_02_06.py
+++ b/Figure_02_06.py
@@ -2,7 +2,6 @@ import sympy
 import numpy
 from scipy import signal
 import matplotlib.pyplot as plt
-get_ipython().magic('matplotlib notebook')
 
 s = sympy.Symbol('s')
 G = 3*(-2*s+1)/((10*s+1)*(5*s+1))
@@ -25,4 +24,4 @@ for i in yt:
     plt.plot(i[0], i[1])
 leg = ["Kc = " + str(i) for i in Kc]
 plt.legend(leg, loc = 6,  bbox_to_anchor=(0.85, 0.9))
-
+plt.show()

--- a/Figure_02_06.py
+++ b/Figure_02_06.py
@@ -1,0 +1,28 @@
+import sympy
+import numpy
+from scipy import signal
+import matplotlib.pyplot as plt
+get_ipython().magic('matplotlib notebook')
+
+s = sympy.Symbol('s')
+G = 3*(-2*s+1)/((10*s+1)*(5*s+1))
+#Controller gains
+Kc= [0.5, 1.5, 2.5, 3.0]
+#Closed-loop transfer function
+Y=[sympy.simplify(i*G/(1+i*G)) for i in Kc]
+#Split into numerator and denominator, get coefficients
+numden = [[sympy.poly(sympy.numer(i)), sympy.poly(sympy.denom(i))] for i in Y]
+numdenc = [[i[0].all_coeffs(), i[1].all_coeffs()] for i in numden]
+#lti model
+ylti = [signal.lti([float(j) for j in i[0]], [float(k) for k in i[1]]) for i in numdenc]
+t = numpy.linspace(0, 50, num=200)
+#step response
+yt = [signal.lti.step(i, T=t) for i in ylti]
+axes = plt.gca()
+axes.set_ylim([-0.5, 2.5])
+axes.set_xlabel('Time[sec]')
+for i in yt:
+    plt.plot(i[0], i[1])
+leg = ["Kc = " + str(i) for i in Kc]
+plt.legend(leg, loc = 6,  bbox_to_anchor=(0.85, 0.9))
+

--- a/Figure_02_06_sympy.py
+++ b/Figure_02_06_sympy.py
@@ -1,7 +1,7 @@
 import sympy
 import numpy
 import matplotlib.pyplot as plt
-get_ipython().magic('matplotlib notebook')
+
 
 s, t = sympy.symbols('s, t')
 G = 3*(-2*s+1)/((10*s+1)*(5*s+1))
@@ -19,8 +19,9 @@ axes = plt.gca()
 axes.set_ylim([-0.5, 2.5])
 axes.set_xlabel('Time[sec]')
 
-for i in ytm:
-    plt.plot(tm, i)
+for i in yt:
+    plt.plot(t, i)
 
 leg = ["Kc = " + str(float(i)) for i in Kc]
 plt.legend(leg, loc = 6,  bbox_to_anchor=(0.85, 0.9))
+plt.show()

--- a/Figure_02_06_sympy.py
+++ b/Figure_02_06_sympy.py
@@ -1,0 +1,26 @@
+import sympy
+import numpy
+import matplotlib.pyplot as plt
+get_ipython().magic('matplotlib notebook')
+
+s, t = sympy.symbols('s, t')
+G = 3*(-2*s+1)/((10*s+1)*(5*s+1))
+#Controller gains
+Kc= [sympy.Rational(1/2), sympy.Rational(3/2), sympy.Rational(5/2), sympy.Rational(3)]
+#Closed loop step response transfer function (closed loop * 1/s)
+Y=[sympy.simplify(i*G/(s*(1+i*G))) for i in Kc]
+#step response in time domain
+y=[sympy.inverse_laplace_transform(i, s, t) for i in Y]
+
+t = numpy.linspace(0.001, 50, num=200)
+yt = [[numpy.real(complex(i.subs(t, j).n())) for j in t ] for i in y]
+
+axes = plt.gca()
+axes.set_ylim([-0.5, 2.5])
+axes.set_xlabel('Time[sec]')
+
+for i in ytm:
+    plt.plot(tm, i)
+
+leg = ["Kc = " + str(float(i)) for i in Kc]
+plt.legend(leg, loc = 6,  bbox_to_anchor=(0.85, 0.9))

--- a/Figure_02_08.py
+++ b/Figure_02_08.py
@@ -2,7 +2,6 @@ import sympy
 from scipy import signal
 import numpy
 import matplotlib.pyplot as plt
-get_ipython().magic('matplotlib notebook')
 
 s = sympy.Symbol('s')
 G = 3*(-2*s+1)/((10*s+1)*(5*s+1))
@@ -31,3 +30,4 @@ plt.plot(ut[0], ut[1])
 
 leg = ["y(t)", "u(t)"]
 plt.legend(leg, loc = 6,  bbox_to_anchor=(0.85, 0.9))
+plt.show()

--- a/Figure_02_08.py
+++ b/Figure_02_08.py
@@ -1,0 +1,33 @@
+import sympy
+from scipy import signal
+import numpy
+import matplotlib.pyplot as plt
+get_ipython().magic('matplotlib notebook')
+
+s = sympy.Symbol('s')
+G = 3*(-2*s+1)/((10*s+1)*(5*s+1))
+K= 1.14*(1+1/(12.7*s))
+#closed loop transfer function
+Y= sympy.simplify(K*G/(1+K*G))
+#Controller output transfer function
+U = sympy.simplify(K/(1+K*G))
+#Split into numerator and denominator
+numden = [[sympy.poly(sympy.numer(Y)), sympy.poly(sympy.denom(Y))], [sympy.poly(sympy.numer(U)), sympy.poly(sympy.denom(Y))]]
+#Get coefficients
+numdenc = [[i.all_coeffs() for i in j] for j in numden]
+#LTI models
+[y, u] = [signal.lti([float(i) for i in numc], [float(j) for j in denc]) for numc, denc in numdenc]
+#Step responses
+t = numpy.linspace(0, 80, num=200)
+yt = signal.lti.step(y, T=t)
+ut = signal.lti.step(u, T=t)
+
+axes = plt.gca()
+axes.set_ylim([-0.5, 2.0])
+axes.set_xlabel('Time[sec]')
+
+plt.plot(yt[0], yt[1])
+plt.plot(ut[0], ut[1])
+
+leg = ["y(t)", "u(t)"]
+plt.legend(leg, loc = 6,  bbox_to_anchor=(0.85, 0.9))

--- a/Figure_02_09.py
+++ b/Figure_02_09.py
@@ -1,9 +1,7 @@
-
 import sympy
 from scipy import signal
 import numpy
 import matplotlib.pyplot as plt
-get_ipython().magic('matplotlib notebook')
 
 s = sympy.Symbol('s')
 G = 4/((s-1)*(0.02*s+1)**2)
@@ -32,3 +30,4 @@ plt.plot(ut[0], ut[1])
 
 leg = ["y(t)", "u(t)"]
 plt.legend(leg, loc = 6,  bbox_to_anchor=(0.85, 0.9))
+plt.show()

--- a/Figure_02_09.py
+++ b/Figure_02_09.py
@@ -1,0 +1,34 @@
+
+import sympy
+from scipy import signal
+import numpy
+import matplotlib.pyplot as plt
+get_ipython().magic('matplotlib notebook')
+
+s = sympy.Symbol('s')
+G = 4/((s-1)*(0.02*s+1)**2)
+K= 1.25*(1+1/(1.5*s))
+#Closed loop tansfer function
+Y= sympy.simplify(K*G/(1+K*G))
+#Closed loop controller output transfer function
+U = sympy.simplify(K/(1+K*G))
+#Split into numerator and denominator
+numden = [[sympy.poly(sympy.numer(Y)), sympy.poly(sympy.denom(Y))], [sympy.poly(sympy.numer(U)), sympy.poly(sympy.denom(Y))]]
+#Get coefficients
+numdenc = [[i.all_coeffs() for i in j] for j in numden]
+#LTI models
+[y, u] = [signal.lti([float(i) for i in numc], [float(j) for j in denc]) for numc, denc in numdenc]
+#Step response
+t = numpy.linspace(0, 4, num=200)
+yt = signal.lti.step(y, T=t)
+ut = signal.lti.step(u, T=t)
+
+axes = plt.gca()
+axes.set_ylim([-0.5, 1.5])
+axes.set_xlabel('Time[sec]')
+
+plt.plot(yt[0], yt[1])
+plt.plot(ut[0], ut[1])
+
+leg = ["y(t)", "u(t)"]
+plt.legend(leg, loc = 6,  bbox_to_anchor=(0.85, 0.9))

--- a/utils.py
+++ b/utils.py
@@ -134,34 +134,18 @@ class tf(object):
     def simplify(self, dec=5):
 
         # Polynomial simplification
-        g = polygcd(self.numerator, self.denominator)
-        self.numerator, remainder = self.numerator/g
-        assert numpy.allclose(remainder.coeffs, 0, atol=1e-6), "Error in simplifying rational, remainder=\n{}".format(remainder)
-        self.denominator, remainder = self.denominator/g
-        assert numpy.allclose(remainder.coeffs, 0, atol=1e-6), "Error in simplifying rational, remainder=\n{}".format(remainder)
-
-        # Round numerator and denominator for coefficient simplification
-        self.numerator = numpy.poly1d(numpy.round(self.numerator, dec))
-        self.denominator = numpy.poly1d(numpy.round(self.denominator, dec))
-
-        # Determine most digits in numerator & denominator
-        num_dec = 0
-        den_dec = 0
-        for i in range(len(self.numerator.coeffs)):
-            num_dec = max(num_dec, decimals(self.numerator.coeffs[i]))
-        for j in range(len(self.denominator.coeffs)):
-            den_dec = max(den_dec, decimals(self.denominator.coeffs[j]))
-
-        # Convert coefficients to integers
-        self.numerator = self.numerator*10**(max(num_dec, den_dec))
-        self.denominator = self.denominator*10**(max(num_dec, den_dec))
-
-        # Decimal-less representation of coefficients
-        num_gcd = gcd(self.numerator.coeffs)
-        den_gcd = gcd(self.denominator.coeffs)
-        tf_gcd = gcd([num_gcd, den_gcd])
-        self.numerator = self.numerator/tf_gcd
-        self.denominator = self.denominator/tf_gcd
+        k = self.numerator[self.numerator.order]/self.denominator[self.denominator.order]
+        ps = self.poles().tolist()
+        zs = self.zeros().tolist()
+        
+        for i in zs:
+            for j in ps:
+                if abs(i-j)< dec:
+                    zs.remove(i)
+                    ps.remove(j)
+        
+        self.numerator = k*numpy.poly1d(zs, True)
+        self.denominator = numpy.poly1d(ps, True)
 
         # Zero-gain transfer functions are special.  They effectively have no
         # dead time and can be simplified to a unity denominator


### PR DESCRIPTION
Here's the fixed code for float tf's. As discussed, I had to change some of the examples in utils.py, as the new method basically gets the tf to pole-zero-gain form (the leading coefficient of the denominator is always 1). I had to modifiy example_05_04.py as well, basically this example contained a bunch of code that tried to get the poles and zero's to cancel correctly, this was now redundant and caused some issues, so I removed it. I also had to change prec from 5 to 3 in __init__. This is because the roots of the polynomials (given by poly1d.r) are only accurate to about 4 decimal places for higher order polynomials (4th order), I was quite surprised by this.