### PR TITLE
utils fixed for pz cancellation

### DIFF
--- a/Example_05_04.py
+++ b/Example_05_04.py
@@ -13,38 +13,11 @@ G = 5/((s - 3)*(10*s + 1))
 Gd_noDT = 0.5/((s - 3)*(0.2*s + 1))
 Gd = add_deadtime_SISO(Gd_noDT,1.5)
 
-def symbolic_poly(coeff):
-    sym = 0
-    s = sp.Symbol('s')
-    for n in range(len(coeff)):
-        sym = (sym + coeff[-n - 1] * s**n).simplify()
-    return sym
-
-def ceoff_symbolic_poly(expr):
-    expr_poly = sp.Poly(expr)
-    coeff  = [float(k) for k in expr_poly.all_coeffs()]
-    return coeff
-
 def Gstable(G,poles):
     Gmul = 1
     for p in poles:
         Gmul *= (s - p)/(s + p)
-    Gs = Gmul*G
-    num = Gs.numerator.c
-    den = Gs.denominator.c
-    sym_num = symbolic_poly(num)
-    sym_den = symbolic_poly(den)
-    fraction = (sym_num/sym_den).simplify()
-    numer, denom = fraction.as_numer_denom()
-    if numer.find('s'):
-        num_coeff  = ceoff_symbolic_poly(numer)
-    else:
-        num_coeff = as_int(numer)
-    if denom.find('s'):
-        den_coeff  = ceoff_symbolic_poly(denom)
-    else:
-        den_coeff = denom
-    return tf(num_coeff,den_coeff)
+    return Gmul*G
 
 
 G_RHPpoles = RHPonly(G.poles())


### PR DESCRIPTION
Here's the code written for pole zero cancellation while not checking every possible root combination. I've managed to skip checking conjugate pairs. Unfortunately this wasn't as simple as just sorting by the real components, I had to sort for the imaginary parts too in order to correctly handle repeated roots. A repeated root tends to turn into a cluster of different roots (all approximately equal). If there is another root with almost the same real part but a different imaginary part that gets into the mix along with the the repeated root, then it would be very easy to miss a cancellation if the imaginary parts haven't been sorted. Otherwise we're back to checking every possible combination.

I've done a bit of research on gcd algorithms, and it seems like it's not easy problem to create an algorithm that is robust, stable and computationally efficient. The approach I have taken is robust and stable, with room for improvement for computational efficiency, but seeing as most tf's we deal with are 1st or 2nd order, and we're only dealing with 2 tf's at a time, I don't believe this is a big issue (the algorithms I've seen online are a bit above me mathematically, but they're for dealing with finding an approximate gcd's for many high order polynomials at a time).

While I've managed to skip some of the steps in the for loops by cancelling conjugate pairs, this required six sorts before hand, so I'm not sure if it's more or less computationally efficient overall, but the code is quite a bit more complex, so I think I prefer my original method, what would your advice be?