### PR TITLE
Removed unused code from utils.py and fixed utils.minimal_realisation

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2034,13 +2034,13 @@ def minimal_realisation(a, b, c):
         Ac, Bc, Cc = kalman_controllable(
             a, b, c, P=C, RP=rank_C)
 
-        Oc = state_observability_matrix(Ac, Cc)
-        rank_Oc = numpy.linalg.matrix_rank(Oc.T)
+        ObsCont = state_observability_matrix(Ac, Cc)
+        rank_ObsCont = numpy.linalg.matrix_rank(ObsCont.T)
         n_statesC = numpy.shape(Ac)[0]
         
-        if rank_Oc < n_statesC:
+        if rank_ObsCont < n_statesC:
             Aco, Bco, Cco = kalman_observable(
-                Ac, Bc, Cc, Q=Oc, RQ=rank_Oc)
+                Ac, Bc, Cc, Q=ObsCont, RQ=rank_ObsCont)
         else:
             return Ac, Bc, Cc
 
@@ -2048,13 +2048,13 @@ def minimal_realisation(a, b, c):
         Ao, Bo, Co = kalman_observable(
             a, b, c, Q=O, RQ=rank_O)
 
-        _, _, Co = state_controllability(Ao, Bo)
-        rank_Co = numpy.linalg.matrix_rank(Co)
+        _, _, ContObs = state_controllability(Ao, Bo)
+        rank_ContObs = numpy.linalg.matrix_rank(ContObs)
         n_statesO = numpy.shape(Ao)[0]
 
-        if rank_Co < n_statesO:
+        if rank_ContObs < n_statesO:
             Aco, Bco, Cco = kalman_controllable(
-                Ao, Bo, Co, P=Co, RP=rank_Co)
+                Ao, Bo, Co, P=ContObs, RP=rank_ContObs)
         else:
             return Ao, Bo, Co
     else:

--- a/utils.py
+++ b/utils.py
@@ -11,8 +11,6 @@ import scipy
 import sympy  # do not abbreviate this module as sp in utils.py
 from scipy import optimize, signal
 import scipy.linalg as sc_linalg
-import fractions
-from decimal import Decimal
 from functools import reduce
 import itertools
 
@@ -743,15 +741,6 @@ def circle(cx, cy, r):
     x = cx + numpy.cos(theta)*r
     return x, y
 
-
-def gcd(ar):
-    return reduce(fractions.gcd, ar)
-
-
-def decimals(fl):
-    fl = str(fl)
-    dec = abs(Decimal(fl).as_tuple().exponent)
-    return dec
 
 def common_roots_ind(a, b, dec=3):
     #Returns the indices of common (approximately equal) roots


### PR DESCRIPTION
As discussed, removed unused code after poly_gcd and poly_lcm fixes.

Also, fixed the issue with minimal realisation by using kalman_observable and kalman_controllable to remove the states. I had to modify the examples to get no errors on run utils.py because the  values of the minimal realisation were different with this approach. I checked that the examples are equivalent and correct by using the condition A2 = T^-1 * A1 * T,  B2 = T^-1 * B, C2 = C1 * T with T = contrabillity_matrix(A1,B1) * controlabillity_matrix_transpose(A2,B2) *(controlabillity_matrix(A2,B2) * controlabillity_matrix_transpose(A2,B2))^-1 and by comparing the results with equivalent results obtained on wolfram alpha, just to be sure. This resolves the issue I posted.

In the last commit I fixed a typo, I had accidentally re-used a variable name I wasn't supposed to...