### PR TITLE
Correction to Example 6.4

### DIFF
--- a/Example_06_04.py
+++ b/Example_06_04.py
@@ -2,15 +2,12 @@ from __future__ import print_function
 from utils import pole_zero_directions, BoundKS, tf, mimotf
 from reporting import display_export_data
 
-import numpy as np
-
 s = tf([1, 0])
 
-G11 = (s - 2.5) / (s - 2)
-G12 = -(0.1 * s + 1) / (s + 2)
-G21 = (s - 2.5) / (0.1 * s + 1)
+G11 = (s + 2.5) / (s - 2)
+G12 = -(0.1 * s + 1) / (s - 2)
+G21 = (s + 2.5) / (0.1 * s + 1)
 G22 = 1
-
 G = mimotf([[G11, G12],
             [G21, G22]])
 
@@ -30,10 +27,8 @@ Gs = mimotf([[G11, G12],
 
 # select RHP-pole
 p = [2.]
-pdir = pole_zero_directions(Gs, p, 'p')
+pdir = pole_zero_directions(G, p, 'p')
 display_export_data(pdir, 'Poles', ['   u', '   y', '   e '])
 
-# e is 0, thus the calculated vectors are not valid
-up = np.matrix([[0.966],
-                [-0.258]])
-print('||KS|| > {:.3}'.format(BoundKS(Gs, p, up)))
+up = pdir[0][1]
+print('||KS||inf >= {:.3}'.format(BoundKS(Gs, p, up)))


### PR DESCRIPTION
Input pole directions of Gs calculated instead of G, therefore the mismatch with the textbook values.  Forced values replaced with calculated values.